### PR TITLE
Fix for double/single quote strings in powershell brush and updated verbs and keywords

### DIFF
--- a/lib/brush-powershell.js
+++ b/lib/brush-powershell.js
@@ -37,7 +37,7 @@
 			
 			{ regex: new RegExp('@"\\n[\\s\\S]*?\\n"@', 'gm'),												css: 'script string here' },			// double quoted here-strings
 			{ regex: new RegExp("@'\\n[\\s\\S]*?\\n'@", 'gm'),												css: 'script string single here' },		// single quoted here-strings
-			{ regex: new RegExp('"(?:\\$\\([^\\)]*\\)|[^"]|`"|"")*[^`]"','g'),								css: 'string' },						// double quoted strings
+			{ regex: new RegExp('"(?:\\$\\([^\\)]*\\)|[^"]|`"|"")*[^`"]?"','g'),								css: 'string' },						// double quoted strings
 			{ regex: new RegExp("'(?:[^']|'')*'", 'g'),														css: 'string single' },					// single quoted strings
 			
 			{ regex: new RegExp('[\\$|@|@@](?:(?:global|script|private|env):)?[A-Z0-9_]+', 'gi'),			css: 'variable' },						// $variables

--- a/lib/brush-powershell.js
+++ b/lib/brush-powershell.js
@@ -19,13 +19,15 @@
 						'imatch ine inotcontains inotlike inotmatch ireplace is isnot le like ' +
 						'lt match ne not notcontains notlike notmatch or regex replace wildcard';
 						
-		var verbs =		'write where wait use update unregister undo trace test tee take suspend ' +
-						'stop start split sort skip show set send select scroll resume restore ' +
-						'restart resolve resize reset rename remove register receive read push ' +
-						'pop ping out new move measure limit join invoke import group get format ' +
-						'foreach export expand exit enter enable disconnect disable debug cxnew ' +
-						'copy convertto convertfrom convert connect complete compare clear ' +
-						'checkpoint aggregate add';
+		var verbs =		'write watch wait use update unregister unpublish unprotect unlock uninstall undo ' +
+						'unblock trace test sync switch suspend submit stop step start split ' +
+						'skip show set send select search save revoke resume restore restart resolve ' +
+						'resize reset request repair rename remove register redo receive read push ' +
+						'publish protect pop ping out optimize open new move mount merge measure ' +
+						'lock limit join invoke install initialize import hide group grant get ' +
+						'format find export expand exit enter enable edit dismount disconnect disable ' +
+						'deny debug copy convertto convertfrom convert connect confirm compress complete ' +
+						'compare close clear checkpoint block backup assert approve add ';
 
 		// I can't find a way to match the comment based help in multi-line comments, because SH won't highlight in highlights, and javascript doesn't support lookbehind
 		var commenthelp = ' component description example externalhelp forwardhelpcategory forwardhelptargetname forwardhelptargetname functionality inputs link notes outputs parameter remotehelprunspace role synopsis';

--- a/lib/brush-powershell.js
+++ b/lib/brush-powershell.js
@@ -6,12 +6,13 @@
 	function Brush()
 	{
 		// Contributed by Joel 'Jaykul' Bennett, http://PoshCode.org | http://HuddledMasses.org
-		var keywords =	'while validateset validaterange validatepattern validatelength validatecount ' +
-						'until trap switch return ref process param parameter in if global: '+
-						'function foreach for finally filter end elseif else dynamicparam do default ' +
-						'continue cmdletbinding break begin alias \\? % #script #private #local #global '+
-						'mandatory parametersetname position valuefrompipeline ' +
-						'valuefrompipelinebypropertyname valuefromremainingarguments helpmessage ';
+		var keywords =	'workflow while var valuefromremainingarguments valuefrompipelinebypropertyname valuefrompipeline ' +
+						'validateset validatescript validaterange validatepattern validatenotnullorempty '+
+						'validatenotnull validatelength validatecount using until try trap throw switch ' +
+						'sequence script: return ref process private: position parametersetname parameter '+
+						'param parallel mandatory local: inlinescript in if hidden helpmessage global: ' +
+						'do define default data continue cmdletbinding class catch break begin allownull ' +
+						'allowemptystring allowemptycollection alias \\? % #script #private #local #global ';
 
 		var operators =	' and as band bnot bor bxor casesensitive ccontains ceq cge cgt cle ' +
 						'clike clt cmatch cne cnotcontains cnotlike cnotmatch contains ' +
@@ -27,7 +28,7 @@
 						'lock limit join invoke install initialize import hide group grant get ' +
 						'format find export expand exit enter enable edit dismount disconnect disable ' +
 						'deny debug copy convertto convertfrom convert connect confirm compress complete ' +
-						'compare close clear checkpoint block backup assert approve add ';
+						'compare close clear checkpoint block backup assert approve add';
 
 		// I can't find a way to match the comment based help in multi-line comments, because SH won't highlight in highlights, and javascript doesn't support lookbehind
 		var commenthelp = ' component description example externalhelp forwardhelpcategory forwardhelptargetname forwardhelptargetname functionality inputs link notes outputs parameter remotehelprunspace role synopsis';


### PR DESCRIPTION
Fixed a bug with empty double quoted strings ("") which would bleed ignoring the closing quote.
Fixed a bug where double quoted strings ending in "`" would incorrectly show as closed strings.
